### PR TITLE
Update mailmate Label

### DIFF
--- a/fragments/labels/mailmate.sh
+++ b/fragments/labels/mailmate.sh
@@ -2,6 +2,7 @@ mailmate)
     # info: It is now recommended for new users to use the latest beta release of MailMate instead of the public release, see https://freron.com/download/
     name="MailMate"
     type="tbz"
+    versionKey="CFBundleVersion"
     downloadURL="https://updates.mailmate-app.com/archives/MailMateBeta.tbz"
     appNewVersion="$(curl -fs https://updates.mailmate-app.com/beta_release_notes | grep Revision | head -n 1 | sed -E 's/.* ([0-9\.]*) .*/\1/g')"
     expectedTeamID="VP8UL4YCJC"


### PR DESCRIPTION
`CFBundleVersion` is holding the correct version corresponding to the `appNewVersion` check